### PR TITLE
Feature/ad 58 emails fix

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 # app/models/user.rb
 class User < ApplicationRecord
-  devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable, :trackable
+  devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable, :trackable, :confirmable
   after_save :set_default_avatar # Cannot occur after_create because of seed
   after_update :purge_unattached_avatars, if: -> { avatar.changed? }
   after_create :mail_admins, unless: -> { approved? }

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,3 @@
-<p>Welcome <%= @email %>!</p>
-
 <p>You can confirm your account email through the link below:</p>
 
 <p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,5 +1,3 @@
-<p>Hello <%= @email %>!</p>
-
 <% if @resource.try(:unconfirmed_email?) %>
   <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
 <% else %>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,3 +1,1 @@
-<p>Hello <%= @resource.email %>!</p>
-
 <p>We're contacting you to notify you that your password has been changed.</p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,5 +1,3 @@
-<p>Hello <%= @resource.email %>!</p>
-
 <p>Someone has requested a link to change your password. You can do this through the link below.</p>
 
 <p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,5 +1,3 @@
-<p>Hello <%= @resource.email %>!</p>
-
 <p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
 
 <p>Click the link below to unlock your account:</p>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -160,7 +160,7 @@ Devise.setup do |config|
   config.reconfirmable = true
 
   # Defines which key will be used when confirming an account
-  # config.confirmation_keys = [:email]
+  config.confirmation_keys = [:email]
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,13 +24,13 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'agordawn-demo@legaltech.wales'
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = 'Devise::Mailer'
 
   # Configure the parent class responsible to send e-mails.
-  # config.parent_mailer = 'ActionMailer::Base'
+  config.parent_mailer = 'ApplicationMailer'
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and
@@ -129,10 +129,10 @@ Devise.setup do |config|
   # config.pepper = '26f2aaacff2886b80505baea993502682674ef09d768607252c9b56a013d21ebb0ad1b7adc0b667624e0ebeacb0834c06cea06c52463c4117bee86073fda617e'
 
   # Send a notification to the original email when the user's email is changed.
-  # config.send_email_changed_notification = false
+  config.send_email_changed_notification = true
 
   # Send a notification email when the user's password is changed.
-  # config.send_password_change_notification = false
+  config.send_password_change_notification = true
 
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without
@@ -219,7 +219,7 @@ Devise.setup do |config|
   # ==> Configuration for :recoverable
   #
   # Defines which key will be used when recovering the password for an account
-  # config.reset_password_keys = [:email]
+  config.reset_password_keys = [:email]
 
   # Time interval you can reset your password with a reset password key.
   # Don't put a too small interval or your users won't have the time to

--- a/db/migrate/20210719145858_devise_create_users.rb
+++ b/db/migrate/20210719145858_devise_create_users.rb
@@ -22,10 +22,10 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.1]
       t.string   :last_sign_in_ip
 
       ## Confirmable
-      # t.string   :confirmation_token
-      # t.datetime :confirmed_at
-      # t.datetime :confirmation_sent_at
-      # t.string   :unconfirmed_email # Only if using reconfirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
 
       ## Lockable
       # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
@@ -47,7 +47,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.1]
 
     add_index :users, :email,                unique: true
     add_index :users, :reset_password_token, unique: true
-    # add_index :users, :confirmation_token,   unique: true
+    add_index :users, :confirmation_token,   unique: true
     # add_index :users, :unlock_token,         unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -110,6 +110,10 @@ ActiveRecord::Schema.define(version: 2021_09_14_102900) do
     t.datetime "last_sign_in_at"
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
     t.boolean "admin", default: false
     t.string "first_name", default: "", null: false
     t.string "last_name", default: "", null: false
@@ -119,6 +123,7 @@ ActiveRecord::Schema.define(version: 2021_09_14_102900) do
     t.boolean "approved", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/seeds/01_users.rb
+++ b/db/seeds/01_users.rb
@@ -25,6 +25,7 @@ unless User.find_by_email('philr@purpleriver.dev').present?
     admin: true,
     approved: true
   )
+  user.skip_confirmation!
   attach_image(user)
 end
 
@@ -38,6 +39,7 @@ unless User.find_by_email('ieuan.skinner@swansea.ac.uk').present?
     admin: true,
     approved: true
   )
+  user.skip_confirmation!
   attach_image(user)
 end
 
@@ -51,7 +53,9 @@ unless User.find_by_email('a.j.wing@swansea.ac.uk').present?
     admin: true,
     approved: true
   )
+  user.skip_confirmation!
   attach_image(user)
+
 end
 
 unless User.find_by_email('g.d.andrews@swansea.ac.uk').present?
@@ -64,6 +68,7 @@ unless User.find_by_email('g.d.andrews@swansea.ac.uk').present?
     admin: true,
     approved: true
   )
+  user.skip_confirmation!
   attach_image(user)
 end
 
@@ -77,6 +82,7 @@ end
     admin: false,
     approved: true
   )
+  user.skip_confirmation!
   attach_default(user, index + 1)
 end
 


### PR DESCRIPTION
This PR addresses the [AD-58](https://lilw.atlassian.net/browse/AD-58?atlOrigin=eyJpIjoiNmE4NGIyYmVlOTNjNDIwMGEzMzhiYzkzYzgzZjg0N2QiLCJwIjoiaiJ9) Ticket which outlined that emails were not functioning for resetting passwords. This Pull Request adresses this and includes the implementation of additional email actions. 

- Fixed error on email reset
- Implemented notify emails for changing of passwords/emails
- Implemented confirmation for new users emails on signup & when changing emails

### Emails will now be sent for the following:


![Screenshot 2021-10-06 at 12 10 53 pm](https://user-images.githubusercontent.com/17786854/136192944-c3704d95-174e-44c8-8337-7aa25cd5ab0c.png)


![Screenshot 2021-10-06 at 12 11 18 pm](https://user-images.githubusercontent.com/17786854/136193120-ee129d78-6b2e-45dd-8e1f-ea1d378c5ecb.png)

![Screenshot 2021-10-06 at 12 23 35 pm](https://user-images.githubusercontent.com/17786854/136193586-aa192260-7c00-4ba7-94e3-346e5f49366e.png)


![Screenshot 2021-10-06 at 12 08 52 pm](https://user-images.githubusercontent.com/17786854/136193048-f2c0a83f-4dbd-485b-95cd-8d324989714d.png)

Additionally when users change their emails from their profile. They will have to confirm the new email before it is changed

![Screenshot 2021-10-06 at 12 11 54 pm](https://user-images.githubusercontent.com/17786854/136193837-695125e8-e1e4-44c3-9cea-0bc30573035a.png)

