### PR TITLE
Hotfix/Change the way we route based on user authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 # app/controllers/application_controller.rb
 class ApplicationController < ActionController::Base
+  before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :require_approval
 

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -14,7 +14,7 @@ en:
       last_attempt: "You have one more attempt before your account is locked."
       not_found_in_database: "Invalid %{authentication_keys} or password."
       timeout: "Your session expired. Please sign in again to continue."
-      unauthenticated: "You need to sign in or sign up before continuing."
+      unauthenticated: "This is a closed platform. You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
       confirmation_instructions:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,30 +1,24 @@
 Rails.application.routes.draw do
   devise_for :users
 
-  authenticated :user do
-    resources :users, only: :show
-    resources :admin, only: :index
+  resources :users, only: :show
+  resources :admin, only: :index
 
-    scope 'admin/users/:id', controller: 'admin' do
-      put '/make_admin', action: 'make_admin', as: :make_admin
-      put '/approve', action: 'approve', as: :approve
-      put '/reject', action: 'reject', as: :reject
-    end
-
-    resources :projects do
-      resources :comments, only: %i[create destroy]
-      resource :likes, only: %i[create destroy]
-    end
-
-    resources :flags, only: %i[index create] do
-      put 'resolve', action: 'resolve', on: :member, as: :resolve
-      put 'reject', action: 'reject', on: :member, as: :reject
-    end
-
-    root 'pages#home', as: :authenticated_root
+  scope 'admin/users/:id', controller: 'admin' do
+    put '/make_admin', action: 'make_admin', as: :make_admin
+    put '/approve', action: 'approve', as: :approve
+    put '/reject', action: 'reject', as: :reject
   end
 
-  unauthenticated do
-    root to: redirect('/users/sign_in')
+  resources :projects do
+    resources :comments, only: %i[create destroy]
+    resource :likes, only: %i[create destroy]
   end
+
+  resources :flags, only: %i[index create] do
+    put 'resolve', action: 'resolve', on: :member, as: :resolve
+    put 'reject', action: 'reject', on: :member, as: :reject
+  end
+
+  root 'pages#home', as: :authenticated_root
 end


### PR DESCRIPTION
Currently in the routes.rb file we used two blocks 'authenticated' and 'unauthenticated'. If you are not logged in and try and navigate to an authenticated route, you would expect to be redirected to the login page. However, I have noticed that this isn't the behaviour, and instead, an error is thrown and we get a 404 error. 

To fix this issue, I have removed the two blocks from the routes folder, so that the only routes specified here are for authenticated paths. Then we add `before_action :authenticate_user!` to the ApplicationController. 

For any actions that users don't have to be authenticated for e.g. an about page, we can add a `skip_before_action` call back method to the controllers.

I believe this offers a much better user experience. It's a lot more useful being prompted to log in than an unhelpful 404 page.

I would suggest adding this to other projects i.e. the Include Journey